### PR TITLE
Simplify process of creating a new actor

### DIFF
--- a/src/leappto/actor_support/portannotation.py
+++ b/src/leappto/actor_support/portannotation.py
@@ -78,7 +78,7 @@ def connectactors(actors):
         opcount = 0
         if isinstance(ip.annotation, InitialPortAnnotation):
             continue
-        
+
         if ip.annotation.srcname==All:
             ip.annotation.matchports=[]
 

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -776,9 +776,9 @@ def main():
                            user=parsed.user,
                            identity=parsed.identity)
 
-        for name in os.listdir(os.path.join(scripts_path)):
-            if os.path.isdir(os.path.join(scripts_path, name)):
-                actor_path = os.path.join(scripts_path, name)
+        for actor_name in os.listdir(os.path.join(scripts_path)):
+            if os.path.isdir(os.path.join(scripts_path, actor_name)):
+                actor_path = os.path.join(scripts_path, actor_name)
                 yaml_file = os.path.join(actor_path, 'actordecl.yaml')
 
                 if not os.path.isfile(yaml_file):
@@ -787,14 +787,13 @@ def main():
                 with open(yaml_file, 'r') as stream:
                     try:
                         actor = yaml.load(stream)
-                        actor_name = actor['name']
                         if 'script' in actor:
                             actor_script = os.path.join(actor_path,
                                                         actor['script'])
 
                             if 'inports' in actor:
                                 wf.add_actor(DirAnnotatedShellActor(
-                                    name,
+                                    actor_name,
                                     wf.get_exec_cmd(),
                                     actor_script,
                                     inports = actor['inports'],
@@ -803,7 +802,7 @@ def main():
                                 ))
                             else:
                                 wf.add_actor(DirAnnotatedShellActor(
-                                    name,
+                                    actor_name,
                                     wf.get_exec_cmd(),
                                     actor_script,
                                     outports = actor['outports'],
@@ -811,7 +810,7 @@ def main():
                                 ))
                         else:
                             wf.add_actor(DirAnnotatedFuncActor(
-                                name,
+                                actor_name,
                                 inports = actor['inports'],
                                 outports = actor['outports'],
                                 name = actor_name

--- a/src/leappto/cli.py
+++ b/src/leappto/cli.py
@@ -26,6 +26,7 @@ import shlex
 import errno
 import psutil
 import yaml
+import glob
 
 
 VERSION='leapp-tool {0}'.format(__version__)
@@ -787,10 +788,20 @@ def main():
                 with open(yaml_file, 'r') as stream:
                     try:
                         actor = yaml.load(stream)
+                        actor_script = None
                         if 'script' in actor:
                             actor_script = os.path.join(actor_path,
                                                         actor['script'])
+                        else:
+                            # If no script was defined on yaml file and
+                            # there is only one .sh file on actor dir
+                            # use it as actor script
+                            script_list = glob.glob(os.path.join(actor_path,
+                                                                 '*.sh'))
+                            if len(script_list) == 1:
+                                actor_script = script_list.pop()
 
+                        if actor_script:
                             if 'inports' in actor:
                                 wf.add_actor(DirAnnotatedShellActor(
                                     actor_name,

--- a/src/leappto/scripts/connectivity/actordecl.py
+++ b/src/leappto/scripts/connectivity/actordecl.py
@@ -2,5 +2,3 @@ from leappto.actor_support.portannotation import PortAnnotation, DstPortAnnotati
 from leappto.msgtypes.msgtypes import ConnectivityStatus, Trigger
 
 outports_annotations = {'connectivity_status': PortAnnotation(ConnectivityStatus)}
-
-inports_annotations = {'dummystart': DstPortAnnotation(Trigger, Any) }

--- a/src/leappto/scripts/connectivity/actordecl.yaml
+++ b/src/leappto/scripts/connectivity/actordecl.yaml
@@ -1,4 +1,3 @@
-script : connectivity.sh
 outports :
     - connectivity_status
 inports :

--- a/src/leappto/scripts/connectivity/actordecl.yaml
+++ b/src/leappto/scripts/connectivity/actordecl.yaml
@@ -1,4 +1,3 @@
-name   : connectivity
 script : connectivity.sh
 outports :
     - connectivity_status

--- a/src/leappto/scripts/connectivity/actordecl.yaml
+++ b/src/leappto/scripts/connectivity/actordecl.yaml
@@ -1,4 +1,2 @@
 outports :
     - connectivity_status
-inports :
-    - dummystart

--- a/src/leappto/scripts/docker/actordecl.yaml
+++ b/src/leappto/scripts/docker/actordecl.yaml
@@ -1,4 +1,3 @@
-name     : docker
 script   : docker.sh
 inports  :
     - has_docker

--- a/src/leappto/scripts/docker/actordecl.yaml
+++ b/src/leappto/scripts/docker/actordecl.yaml
@@ -1,4 +1,3 @@
-script   : docker.sh
 inports  :
     - has_docker
 outports :

--- a/src/leappto/scripts/docker_list/actordecl.yaml
+++ b/src/leappto/scripts/docker_list/actordecl.yaml
@@ -1,4 +1,3 @@
-name     : docker_list
 script   : docker_list.sh
 inports  :
     - has_docker

--- a/src/leappto/scripts/docker_list/actordecl.yaml
+++ b/src/leappto/scripts/docker_list/actordecl.yaml
@@ -1,4 +1,3 @@
-script   : docker_list.sh
 inports  :
     - has_docker
 outports :

--- a/src/leappto/scripts/has_docker/actordecl.py
+++ b/src/leappto/scripts/has_docker/actordecl.py
@@ -2,5 +2,3 @@ from leappto.actor_support.portannotation import PortAnnotation, DstPortAnnotati
 from leappto.msgtypes.msgtypes import DockerStatus, DockerListStatus, Trigger
 
 outports_annotations = {'docker_status': PortAnnotation(DockerStatus)}
-
-inports_annotations = {'dummystart': DstPortAnnotation(Trigger, Any) }

--- a/src/leappto/scripts/has_docker/actordecl.yaml
+++ b/src/leappto/scripts/has_docker/actordecl.yaml
@@ -1,4 +1,3 @@
-name   : has_docker
 script : has_docker.sh
 outports :
     - docker_status

--- a/src/leappto/scripts/has_docker/actordecl.yaml
+++ b/src/leappto/scripts/has_docker/actordecl.yaml
@@ -1,5 +1,3 @@
 outports :
     - docker_status
-inports :
-    - dummystart
 

--- a/src/leappto/scripts/has_docker/actordecl.yaml
+++ b/src/leappto/scripts/has_docker/actordecl.yaml
@@ -1,4 +1,3 @@
-script : has_docker.sh
 outports :
     - docker_status
 inports :

--- a/src/leappto/scripts/has_rsync/actordecl.py
+++ b/src/leappto/scripts/has_rsync/actordecl.py
@@ -2,5 +2,3 @@ from leappto.actor_support.portannotation import PortAnnotation, DstPortAnnotati
 from leappto.msgtypes.msgtypes import RsyncStatus, Trigger
 
 outports_annotations = {'rsyncstatus': PortAnnotation(RsyncStatus)}
-
-inports_annotations = {'dummystart': DstPortAnnotation(Trigger, Any) }

--- a/src/leappto/scripts/has_rsync/actordecl.yaml
+++ b/src/leappto/scripts/has_rsync/actordecl.yaml
@@ -1,4 +1,2 @@
 outports:
     - rsyncstatus
-inports :
-    - dummystart

--- a/src/leappto/scripts/has_rsync/actordecl.yaml
+++ b/src/leappto/scripts/has_rsync/actordecl.yaml
@@ -1,4 +1,3 @@
-script : has_rsync.sh
 outports:
     - rsyncstatus
 inports :

--- a/src/leappto/scripts/has_rsync/actordecl.yaml
+++ b/src/leappto/scripts/has_rsync/actordecl.yaml
@@ -1,4 +1,3 @@
-name   : has_rsync
 script : has_rsync.sh
 outports:
     - rsyncstatus

--- a/src/leappto/scripts/output_formatter/actordecl.yaml
+++ b/src/leappto/scripts/output_formatter/actordecl.yaml
@@ -1,4 +1,3 @@
-name   : output_formatter
 outports :
     - msg
 inports:

--- a/src/leappto/scripts/rsync/actordecl.yaml
+++ b/src/leappto/scripts/rsync/actordecl.yaml
@@ -1,4 +1,3 @@
-script   : rsync.sh
 inports  :
     - has_rsync
 outports :

--- a/src/leappto/scripts/rsync/actordecl.yaml
+++ b/src/leappto/scripts/rsync/actordecl.yaml
@@ -1,4 +1,3 @@
-name     : rsync
 script   : rsync.sh
 inports  :
     - has_rsync

--- a/src/leappto/workflow/check.py
+++ b/src/leappto/workflow/check.py
@@ -102,7 +102,6 @@ class CheckWorkflow(object):
         #        def start_workflow(hostname):
         #            """ Simple function to trigger all other actors """
         #            return hostname
-        
         #        start_actor = FuncActor(start_workflow, outports=['out'])
 
         """        input_dict = {}
@@ -132,7 +131,7 @@ class CheckWorkflow(object):
         def start_workflow(hostname):
             """ Simple function to trigger all other actors """
             return Trigger()
-        
+
         start_actor = AnnotatedFuncActor(outports_annotations={'out': PortAnnotation(Trigger)}, inports_annotations={'hostname': InitialPortAnnotation()}, func=start_workflow, outports=('out') )
 
         self.add_actor(start_actor)


### PR DESCRIPTION
- Use actor directory name as actor name;
- If no script is defined via yaml file and there is only one .sh file in dir use it as actor script;
- If no input port is defined via yaml file use default one and trigger actor in the beginning of the workflow